### PR TITLE
removed audit tra has no html tag

### DIFF
--- a/ui/src/app/modules/laboratory/modules/sample-acceptance-and-results/components/results-feeding-modal/results-feeding-modal.component.html
+++ b/ui/src/app/modules/laboratory/modules/sample-acceptance-and-results/components/results-feeding-modal/results-feeding-modal.component.html
@@ -644,7 +644,6 @@
                               <thead class="table-header">
                                 <th>Value</th>
                                 <th>Remarks</th>
-                                Audit Tra
                                 <th>Date Time</th>
                                 <th>Completed By</th>
                               </thead>


### PR DESCRIPTION
"audit tra" which doesn't affect the ui of icare was found in the results-feeding-modal.component.html 