### PR TITLE
:bug: Fix: Can view results in current.

### DIFF
--- a/ui/src/app/modules/laboratory/modules/sample-acceptance-and-results/components/results-feeding-modal/results-feeding-modal.component.html
+++ b/ui/src/app/modules/laboratory/modules/sample-acceptance-and-results/components/results-feeding-modal/results-feeding-modal.component.html
@@ -1059,8 +1059,8 @@
                               ]) ||
                             (parameter?.datatype?.display === 'Complex' &&
                               !file) ||
-                            (!values[parameter?.uuid] &&
-                              !values[parameter?.uuid + '-comment']) ||
+                            (!values[parameter?.uuid])||
+                              (!values[parameter?.uuid + '-comment']) ||
                             (item?.allocationsPairedBySetMember[parameter?.uuid]
                               ?.firstSignOff &&
                               !LISConfigurations?.isLIS)


### PR DESCRIPTION
🐛 **Bug Description** 
Current tab in the view results tab of a completed sample section in the laboratory module does not show data to some of the patient's results.

💣 **What we observed.**
Patients whose data was filled  following the proper channel/ procedures on the RESULTS & APROVAL section  didn't seem to encounter this problem but when the RESULTS entry is  left out on the patients data the described bug above seemed to occur.


![Screenshot (33)](https://user-images.githubusercontent.com/39125180/207310726-211a3920-aebe-42a8-a03d-9ab54a6b59ee.png)

🤷‍♂️ **How was it possible ?**
Initially in the result entry and approval section, the save button was enabled when either of the two (Results and Remarks)  was filled, which lead into the current section (on the completed sample page- which only displays the Result ) being empty when only remarks was filled. The system was able to allow only the remarks section to be filled and saved without the results because of conditions set for the save button.  

<img width="609" alt="Screenshot_20221213_025854" src="https://user-images.githubusercontent.com/39125180/207312139-ab883bd2-8078-4110-81ff-97eced280add.png">


🚧 **What we fixed**
 We changed the conditions on the disabled value of the save button so that it is enabled only when both the result and remarks are filled.

![Screenshot (32)](https://user-images.githubusercontent.com/39125180/207311235-db24e3a8-d1db-4add-8936-28d2975277aa.png)





